### PR TITLE
Update and rename ballarat.txt to federation.txt

### DIFF
--- a/lib/domains/au/edu/ballarat.txt
+++ b/lib/domains/au/edu/ballarat.txt
@@ -1,1 +1,0 @@
-University of Ballarat

--- a/lib/domains/au/edu/federation.txt
+++ b/lib/domains/au/edu/federation.txt
@@ -1,0 +1,1 @@
+Federation University Australia


### PR DESCRIPTION
University of Ballarat renamed to Federation University Australia in 2014.